### PR TITLE
Bseto/fix graphics handler memory leak

### DIFF
--- a/src/Engine/GraphicsHandler/GraphicsHandler.cpp
+++ b/src/Engine/GraphicsHandler/GraphicsHandler.cpp
@@ -42,10 +42,16 @@ void GraphicsHandler::draw(SDL_Texture* texture, int x_pos, int y_pos,
     this->draw(texture, texture_rect, priority, cleanup, angle_clockwise, rotation_point);
 }
 
+//Cleanup refers to the surface when a SDL_Surface* is passed in
 void GraphicsHandler::draw(SDL_Surface* surface, int x_pos, int y_pos,
                            GraphicPriority priority, bool cleanup, double angle_clockwise, SDL_Point* rotation_point) {
     SDL_Texture* texture = SDL_CreateTextureFromSurface(&renderer_, surface);
-    this->draw(texture, x_pos, y_pos, priority, cleanup, angle_clockwise, rotation_point);
+    if (cleanup) {
+        SDL_FreeSurface(surface);
+    }
+    //Setting cleanup to be true regardless of original argument. We created a texture here, and we will not  
+    //be keeping it. GraphicsHandler needs to clean it up for us in the future.
+    this->draw(texture, x_pos, y_pos, priority, true, angle_clockwise, rotation_point);
 }
 
 void GraphicsHandler::draw(SDL_Texture* texture, SDL_Rect texture_rect,
@@ -58,6 +64,7 @@ void GraphicsHandler::draw(SDL_Texture* texture, int x_pos, int y_pos,
     draw(texture, x_pos, y_pos, priority, cleanup, 0, NULL);
 }
 
+//Cleanup refers to the surface when a SDL_Surface* is passed in
 void GraphicsHandler::draw(SDL_Surface* surface, int x_pos, int y_pos,
                            GraphicPriority priority, bool cleanup) {
     draw(surface, x_pos, y_pos, priority, cleanup, 0, NULL);

--- a/src/TerminalFighter/TargetingSystem/TargetingSystem.cpp
+++ b/src/TerminalFighter/TargetingSystem/TargetingSystem.cpp
@@ -102,8 +102,7 @@ void TargetingSystem::draw(I_GraphicsHandler& graphics) {
     for (std::map<int, GameObjectStringPair*>::iterator it = targets_.begin(); it != targets_.end(); ++it) {
         SDL_Surface* UIText = TTF_RenderText_Blended(default_font_, it->second->assigned_word_.c_str(), WHITE);
         graphics.draw(UIText, (int)it->second->game_object_.x_pos(), (int)it->second->game_object_.y_pos(),
-                      GraphicPriority::UI, false);
-        SDL_FreeSurface(UIText);
+                      GraphicPriority::UI, true);
     }
 }
 

--- a/src/TerminalFighter/Terminal/Terminal.cpp
+++ b/src/TerminalFighter/Terminal/Terminal.cpp
@@ -37,8 +37,7 @@ void Terminal::draw(I_GraphicsHandler& graphics) {
     SDL_Color white = {255, 255, 255};
     SDL_Surface* UIText = TTF_RenderText_Blended(default_font_, player_text_.c_str(), white);
     graphics.draw(terminal_texture_, (int)x_pos(), (int)y_pos(), GraphicPriority::UI, true);
-    graphics.draw(UIText, (int)x_pos() + 30, (int)y_pos() + 30, GraphicPriority::UI, false);
-    SDL_FreeSurface(UIText);
+    graphics.draw(UIText, (int)x_pos() + 30, (int)y_pos() + 30, GraphicPriority::UI, true);
 }
 
 const I_Hitbox& Terminal::hitbox() const {


### PR DESCRIPTION
Prior to this change, `bool cleanup` was used to determine if a `SDL_Texture*` needed to be cleaned up by the `GraphicsHandler`. 

https://github.com/JeLLyNinjas/TerminalFighter/blob/5709f99229da6e750ebdf0f829e7eafae1df5abd/src/Engine/GraphicsHandler/GraphicsHandler.cpp#L72

However, this can be confusing as a `SDL_Surface*` can also be passed into a draw function. 


This change makes the `bool cleanup` variable cleanup the `SDL_Surface*` if it is passed into the draw function. It also now correctly handles the `SDL_Texture*` that is created - which has to be free'd later by `GraphicsHandler`. 